### PR TITLE
Add getResponseBody() to http client

### DIFF
--- a/src/React/HttpClient/Client.php
+++ b/src/React/HttpClient/Client.php
@@ -24,7 +24,11 @@ class Client
         $requestData = new RequestData($method, $url, $headers);
         $connectionManager = $this->getConnectorForScheme($requestData->getScheme());
         return new Request($this->loop, $connectionManager, $requestData);
+    }
 
+    public function get($url, array $headers = array())
+    {
+        return $this->request('GET', $url, $headers)->getResponseBody();
     }
 
     private function getConnectorForScheme($scheme)


### PR DESCRIPTION
Hi guys, I just started playing with react and I love it. Though I miss some methods to make my coding easy and pleasant. I'm not sure if this method is in a good place, but it seems convenient to me. Please give me comments if you have other thoughts, as I don't know react well yet.

---

This methods **returns Promise of the response body**, making http request easier with promises.

Making a http request and reading the response is not very convenient at the moment - you need to attach two handlers: on-response + on-data. This method shall make it easier.

Example of use case:
```php
$httpClient->request('GET', 'http://google.com')->getResponseBody()->then(
	function($data) {
		echo htmlspecialchars($data);
	},
	function($err) {
		dump($err);
	}
);
```