### PR TITLE
Open file descriptor as socket

### DIFF
--- a/src/React/Socket/RawServer.php
+++ b/src/React/Socket/RawServer.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace React\Socket;
+
+use Evenement\EventEmitter;
+use React\EventLoop\LoopInterface;
+
+/** @event connection */
+class RawServer extends EventEmitter implements ServerInterface
+{
+    public $master;
+    private $loop;
+
+    public function __construct(LoopInterface $loop)
+    {
+        $this->loop = $loop;
+    }
+
+    public function listen($socket)
+    {
+        $this->master = @stream_socket_server($socket, $errno, $errstr);
+        if (false === $this->master) {
+            $message = "Could not bind to $socket: $errstr";
+            throw new ConnectionException($message, $errno);
+        }
+        stream_set_blocking($this->master, 0);
+
+        $this->loop->addReadStream($this->master, function ($master) {
+            $newSocket = stream_socket_accept($master);
+            if (false === $newSocket) {
+                $this->emit('error', array(new \RuntimeException('Error accepting new connection')));
+
+                return;
+            }
+            $this->handleConnection($newSocket);
+        });
+    }
+
+    public function handleConnection($socket)
+    {
+        stream_set_blocking($socket, 0);
+
+        $client = $this->createConnection($socket);
+
+        $this->emit('connection', array($client));
+    }
+
+    public function getPort()
+    {
+        $name = stream_socket_get_name($this->master, false);
+
+        return (int) substr(strrchr($name, ':'), 1);
+    }
+
+    public function shutdown()
+    {
+        $this->loop->removeStream($this->master);
+        fclose($this->master);
+        $this->removeAllListeners();
+    }
+
+    public function createConnection($socket)
+    {
+        return new Connection($socket, $this->loop);
+    }
+}

--- a/src/React/Socket/Server.php
+++ b/src/React/Socket/Server.php
@@ -6,16 +6,8 @@ use Evenement\EventEmitter;
 use React\EventLoop\LoopInterface;
 
 /** @event connection */
-class Server extends EventEmitter implements ServerInterface
+class Server extends RawServer
 {
-    public $master;
-    private $loop;
-
-    public function __construct(LoopInterface $loop)
-    {
-        $this->loop = $loop;
-    }
-
     public function listen($port, $host = '127.0.0.1')
     {
         if (strpos($host, ':') !== false) {
@@ -23,49 +15,6 @@ class Server extends EventEmitter implements ServerInterface
             $host = '[' . $host . ']';
         }
 
-        $this->master = @stream_socket_server("tcp://$host:$port", $errno, $errstr);
-        if (false === $this->master) {
-            $message = "Could not bind to tcp://$host:$port: $errstr";
-            throw new ConnectionException($message, $errno);
-        }
-        stream_set_blocking($this->master, 0);
-
-        $this->loop->addReadStream($this->master, function ($master) {
-            $newSocket = stream_socket_accept($master);
-            if (false === $newSocket) {
-                $this->emit('error', array(new \RuntimeException('Error accepting new connection')));
-
-                return;
-            }
-            $this->handleConnection($newSocket);
-        });
-    }
-
-    public function handleConnection($socket)
-    {
-        stream_set_blocking($socket, 0);
-
-        $client = $this->createConnection($socket);
-
-        $this->emit('connection', array($client));
-    }
-
-    public function getPort()
-    {
-        $name = stream_socket_get_name($this->master, false);
-
-        return (int) substr(strrchr($name, ':'), 1);
-    }
-
-    public function shutdown()
-    {
-        $this->loop->removeStream($this->master);
-        fclose($this->master);
-        $this->removeAllListeners();
-    }
-
-    public function createConnection($socket)
-    {
-        return new Connection($socket, $this->loop);
+        return parent::listen("tcp://$host:$port");
     }
 }

--- a/src/React/Socket/ServerInterface.php
+++ b/src/React/Socket/ServerInterface.php
@@ -7,7 +7,7 @@ use Evenement\EventEmitterInterface;
 /** @event connection */
 interface ServerInterface extends EventEmitterInterface
 {
-    public function listen($port, $host = '127.0.0.1');
+    public function listen($socket);
     public function getPort();
     public function shutdown();
 }


### PR DESCRIPTION
If we want to use a react server behind systemd or launchd (socket activation) we should be able to open socket that are not tcp socket.

context:
on Linux, systemd is able to listen to a port instead of a program and start the program when a connexion is open on the port. this allow the system to boot faster, use fewer ressources while the service is not used and restart the service if it crashes (or if we killed it after an upgrade) without losing any connexion

for that, systemd start the program with a an ENV variable telling it which file descriptor to connect to. With React\Socket\Server we can only connect to tcp (eg: "tcp://0.0.0.0:8080") but in this case it should be able to connect to "php://fd/$fd"

I can solve this problem like that:

```php
<?php

namespace My\Namespace\Socket;

use React\EventLoop\LoopInterface;
use React\Socket\Server as ReactTcpOnlyServer;

class Server extends ReactTcpOnlyServer
{
    private $loop;

    public function __construct(LoopInterface $loop)
    {
        $this->loop = $loop;
        parent::__construct($loop);
    }
    
    public function listen($socket, $nada = '')
    {
        $this->master = @stream_socket_server($socket);
        if (false === $this->master) {
            $message = "Could not bind to $socket: $errstr";
            throw new ConnectionException($message, $errno);
        }
        stream_set_blocking($this->master, 0);

        $that = $this;

        $this->loop->addReadStream($this->master, function ($master) use ($that) {
            $newSocket = stream_socket_accept($master);
            if (false === $newSocket) {
                $that->emit('error', array(new \RuntimeException('Error accepting new connection')));

                return;
            }
            $that->handleConnection($newSocket);
        });
    }
}
```

but i think it would be an improvement it it could work out of the box. here the `listen` method should not have 2 parameters.

I propose the following changes 

* `React\Socket\ServerInterface` should not impose the second parameter on the `listen` method. 
* `React\Socket\RawServer` should be implemented with `listen($socket)`
* `React\Socket\Server` should extend `React\Socket\RawServer` and implement `listen($port, $host = '0.0.0.0')`