### PR TITLE
Added answers to binary dumping

### DIFF
--- a/src/Dns/Protocol/BinaryDumper.php
+++ b/src/Dns/Protocol/BinaryDumper.php
@@ -7,12 +7,20 @@ use React\Dns\Model\HeaderBag;
 
 class BinaryDumper
 {
+    /**
+     * @var
+     */
+    private $labelRegistry;
+
     public function toBinary(Message $message)
     {
+        $this->labelRegistry = array();
+
         $data = '';
 
         $data .= $this->headerToBinary($message->header);
         $data .= $this->questionToBinary($message->questions);
+        $data .= $this->answerToBinary($message->answers);
 
         return $data;
     }
@@ -48,15 +56,83 @@ class BinaryDumper
         $data = '';
 
         foreach ($questions as $question) {
-            $labels = explode('.', $question['name']);
-            foreach ($labels as $label) {
-                $data .= chr(strlen($label)).$label;
-            }
-            $data .= "\x00";
+            $data .= $this->encodeDomainName($question['name'], true);
 
             $data .= pack('n*', $question['type'], $question['class']);
         }
 
         return $data;
+    }
+
+    private function answerToBinary(array $answers)
+    {
+        $data = '';
+
+        foreach ($answers as $answer) {
+            $data .= $this->encodeDomainName($answer->name, true);
+
+            $rdata = '';
+            if (Message::TYPE_A === $answer->type) {
+                $rdata .= $this->encodeIpv4Address($answer->data);
+            }
+
+            if (Message::TYPE_CNAME === $answer->type) {
+                $rdata .= $this->encodeDomainName($answer->data, true);
+            }
+
+            $data .= pack('n', $answer->type);
+            $data .= pack('n', $answer->class);
+            $data .= pack('N', $answer->ttl);
+            $data .= pack('n', strlen($rdata));
+            $data .= $rdata;
+        }
+
+        return $data;
+    }
+
+    private function encodeDomainName($domainName, $compress = false)
+    {
+        $data = '';
+
+        $labels = explode('.', $domainName);
+
+        if ($compress) {
+            $packetIndex = 12;
+
+            while (!empty($labels)) {
+                $part = implode('.', $labels);
+
+                if (!isset($this->labelRegistry[$part])) {
+                    $this->labelRegistry[$part] = $packetIndex;
+
+                    $label = array_shift($labels);
+                    $length = strlen($label);
+
+                    $data .= chr($length) . $label;
+                    $packetIndex += $length + 1;
+                } else {
+                    $data .= pack('n', 0b1100000000000000 | $this->labelRegistry[$part]);
+                    break;
+                }
+            }
+
+            if (!$labels) {
+                $data .= "\x00";
+            }
+        } else {
+            foreach ($labels as $label) {
+                $data .= chr(strlen($label)).$label;
+            }
+
+            $data .= "\x00";
+        }
+
+        return $data;
+    }
+
+    private function encodeIpv4Address($ipv4Address)
+    {
+        $octets = explode('.', $ipv4Address);
+        return pack('C*', $octets[0], $octets[1], $octets[2], $octets[3]);
     }
 }

--- a/tests/Dns/Protocol/BinaryDumperTest.php
+++ b/tests/Dns/Protocol/BinaryDumperTest.php
@@ -2,8 +2,10 @@
 
 namespace React\Tests\Dns\Protocol;
 
+use React\Dns\Model\Record;
 use React\Dns\Protocol\BinaryDumper;
 use React\Dns\Model\Message;
+use React\Dns\Protocol\Parser;
 
 class BinaryDumperTest extends \PHPUnit_Framework_TestCase
 {
@@ -28,8 +30,163 @@ class BinaryDumperTest extends \PHPUnit_Framework_TestCase
 
         $request->prepare();
 
+        $this->assertFalse($request->header->isResponse());
+
         $dumper = new BinaryDumper();
         $data = $dumper->toBinary($request);
+        $data = $this->convertBinaryToHexDump($data);
+
+        $this->assertSame($expected, $data);
+    }
+
+    public function testResponseToBinary()
+    {
+        $data = "";
+        $data .= "72 62 81 80 00 01 00 01 00 00 00 00"; // header
+        $data .= "04 69 67 6f 72 02 69 6f 00";          // question: igor.io
+        $data .= "00 01 00 01";                         // question: type A, class IN
+        $data .= "c0 0c";                               // answer: offset pointer to igor.io
+        $data .= "00 01 00 01";                         // answer: type A, class IN
+        $data .= "00 01 51 80";                         // answer: ttl 86400
+        $data .= "00 04";                               // answer: rdlength 4
+        $data .= "b2 4f a9 83";                         // answer: rdata 178.79.169.131
+
+        $expected = $this->formatHexDump(str_replace(' ', '', $data), 2);
+
+        $response = new Message();
+        $response->header->set('id', 0x7262);
+        $response->header->set('rd', 1);
+        $response->header->set('qr', 1);
+        $response->header->set('ra', 1);
+        $response->header->set('opcode', Message::OPCODE_QUERY);
+
+        $response->questions[] = array(
+            'name'  => 'igor.io',
+            'type'  => Message::TYPE_A,
+            'class' => Message::CLASS_IN,
+        );
+
+        $response->answers[] = new Record(
+            'igor.io',
+            Message::TYPE_A,
+            Message::CLASS_IN,
+            86400,
+            '178.79.169.131'
+        );
+
+        $response->prepare();
+
+        $this->assertTrue($response->header->isResponse());
+
+        $dumper = new BinaryDumper();
+        $data = $dumper->toBinary($response);
+        $data = $this->convertBinaryToHexDump($data);
+
+        $this->assertSame($expected, $data);
+    }
+
+    public function testResponseWithCnameAndOffsetPointersToBinary()
+    {
+        $data = "";
+        $data .= "9e 8d 81 80 00 01 00 01 00 00 00 00";                 // header
+        $data .= "04 6d 61 69 6c 06 67 6f 6f 67 6c 65 03 63 6f 6d 00";  // question: mail.google.com
+        $data .= "00 05 00 01";                                         // question: type CNAME, class IN
+        $data .= "c0 0c";                                               // answer: offset pointer to mail.google.com
+        $data .= "00 05 00 01";                                         // answer: type CNAME, class IN
+        $data .= "00 00 a8 9c";                                         // answer: ttl 43164
+        $data .= "00 0f";                                               // answer: rdlength 15
+        $data .= "0a 67 6f 6f 67 6c 65 6d 61 69 6c 01 6c";              // answer: rdata googlemail.l.
+        $data .= "c0 11";                                               // answer: rdata offset pointer to google.com
+
+        $expected = $this->formatHexDump(str_replace(' ', '', $data), 2);
+
+        $response = new Message();
+        $response->header->set('id', 0x9e8d);
+        $response->header->set('rd', 1);
+        $response->header->set('qr', 1);
+        $response->header->set('ra', 1);
+        $response->header->set('opcode', Message::OPCODE_QUERY);
+
+        $response->questions[] = array(
+            'name'  => 'mail.google.com',
+            'type'  => Message::TYPE_CNAME,
+            'class' => Message::CLASS_IN,
+        );
+
+        $response->answers[] = new Record(
+            'mail.google.com',
+            Message::TYPE_CNAME,
+            Message::CLASS_IN,
+            43164,
+            'googlemail.l.google.com'
+        );
+
+        $response->prepare();
+
+        $this->assertTrue($response->header->isResponse());
+
+        $dumper = new BinaryDumper();
+        $data = $dumper->toBinary($response);
+        $data = $this->convertBinaryToHexDump($data);
+
+        $this->assertSame($expected, $data);
+    }
+
+    public function testResponseWithTwoAnswersToBinary()
+    {
+        $data = "";
+        $data .= "bc 73 81 80 00 01 00 02 00 00 00 00";                 // header
+        $data .= "02 69 6f 0d 77 68 6f 69 73 2d 73 65 72 76 65 72 73 03 6e 65 74 00";
+                                                                        // question: io.whois-servers.net
+        $data .= "00 01 00 01";                                         // question: type A, class IN
+        $data .= "c0 0c";                                               // answer: offset pointer to io.whois-servers.net
+        $data .= "00 05 00 01";                                         // answer: type CNAME, class IN
+        $data .= "00 00 00 29";                                         // answer: ttl 41
+        $data .= "00 0e";                                               // answer: rdlength 14
+        $data .= "05 77 68 6f 69 73 03 6e 69 63 02 69 6f 00";           // answer: rdata whois.nic.io
+        $data .= "c0 32";                                               // answer: offset pointer to whois.nic.io
+        $data .= "00 01 00 01";                                         // answer: type CNAME, class IN
+        $data .= "00 00 0d f7";                                         // answer: ttl 3575
+        $data .= "00 04";                                               // answer: rdlength 4
+        $data .= "c1 df 4e 98";                                         // answer: rdata 193.223.78.152
+
+        $expected = $this->formatHexDump(str_replace(' ', '', $data), 2);
+
+        $response = new Message();
+        $response->header->set('id', 0xbc73);
+        $response->header->set('rd', 1);
+        $response->header->set('qr', 1);
+        $response->header->set('ra', 1);
+        $response->header->set('opcode', Message::OPCODE_QUERY);
+
+        $response->questions[] = array(
+            'name'  => 'io.whois-servers.net',
+            'type'  => Message::TYPE_A,
+            'class' => Message::CLASS_IN,
+        );
+
+        $response->answers[] = new Record(
+            'io.whois-servers.net',
+            Message::TYPE_CNAME,
+            Message::CLASS_IN,
+            41,
+            'whois.nic.io'
+        );
+
+        $response->answers[] = new Record(
+            'whois.nic.io',
+            Message::TYPE_A,
+            Message::CLASS_IN,
+            3575,
+            '193.223.78.152'
+        );
+
+        $response->prepare();
+
+        $this->assertTrue($response->header->isResponse());
+
+        $dumper = new BinaryDumper();
+        $data = $dumper->toBinary($response);
         $data = $this->convertBinaryToHexDump($data);
 
         $this->assertSame($expected, $data);


### PR DESCRIPTION
Hi there!

I've added a method for dumping the DNS answers to binaries with corresponding tests. I have used the responses from the ParserTest class to make sure that it's fully compatible.

The only fail is the last test:

```
React\Tests\Dns\Protocol\BinaryDumperTest::testResponseWithTwoAnswersToBinary
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-bc 73 81 80 00 01 00 02 00 00 00 00 02 69 6f 0d 77 68 6f 69 73 2d 73 65 72 76 65 72 73 03 6e 65 74 00 00 01 00 01 c0 0c 00 05 00 01 00 00 00 29 00 0e 05 77 68 6f 69 73 03 6e 69 63 02 69 6f 00 c0 32 00 01 00 01 00 00 0d f7 00 04 c1 df 4e 98
+bc 73 81 80 00 01 00 02 00 00 00 00 02 69 6f 0d 77 68 6f 69 73 2d 73 65 72 76 65 72 73 03 6e 65 74 00 00 01 00 01 c0 0c 00 05 00 01 00 00 00 29 00 0e 05 77 68 6f 69 73 03 6e 69 63 02 69 6f 00 c0 0c 00 01 00 01 00 00 0d f7 00 04 c1 df 4e 98

/Users/robinvdvleuten/Projects/react/tests/Dns/Protocol/BinaryDumperTest.php:192
```

As you can see they are both identical except for the end part:
```
c0 32 00 01 00 01 00 00 0d f7 00 04 c1 df 4e 98
c0 0c 00 01 00 01 00 00 0d f7 00 04 c1 df 4e 98
```

My guess is that it has something to do with `$packetIndex = 12`. But I am not that much of a binary expert so hopefully you guys are willing to help me there :)