### PR TITLE
Added  getRemotePort method to Connection

### DIFF
--- a/src/Socket/Connection.php
+++ b/src/Socket/Connection.php
@@ -31,8 +31,18 @@ class Connection extends Stream implements ConnectionInterface
         return $this->parseAddress(stream_socket_get_name($this->stream, true));
     }
 
+    public function getRemotePort()
+    {
+        return $this->parsePort(stream_socket_get_name($this->stream, true));
+    }
+
     private function parseAddress($address)
     {
         return trim(substr($address, 0, strrpos($address, ':')), '[]');
+    }
+
+    private function parsePort($address)
+    {
+        return (int) substr($address, strrpos($address, ':') + 1);
     }
 }

--- a/src/Socket/ConnectionInterface.php
+++ b/src/Socket/ConnectionInterface.php
@@ -9,4 +9,6 @@ use React\Stream\WritableStreamInterface;
 interface ConnectionInterface extends ReadableStreamInterface, WritableStreamInterface
 {
     public function getRemoteAddress();
+
+    public function getRemotePort();
 }

--- a/tests/Socket/ConnectionTest.php
+++ b/tests/Socket/ConnectionTest.php
@@ -70,6 +70,34 @@ class ConnectionTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
+    public function remotePortProvider()
+    {
+        return array(
+            array(12345, '192.168.1.120:12345')
+          , array(12345, '[9999:0000:aaaa:bbbb:cccc:dddd:eeee:ffff]:12345')
+          , array(80, '10.0.0.1:80')
+        );
+    }
+
+    /**
+     * @dataProvider remotePortProvider
+     * @covers React\Socket\Connection::parsePort
+     */
+    public function testParsePort($expected, $given)
+    {
+        $class  = new \ReflectionClass('React\\Socket\\Connection');
+        $method = $class->getMethod('parsePort');
+        $method->setAccessible(true);
+
+        $socket = fopen('php://temp', 'r');
+        $loop   = $this->createLoopMock();
+
+        $conn = new Connection($socket, $loop);
+        $result = $method->invokeArgs($conn, array($given));
+
+        $this->assertEquals($expected, $result);
+    }
+
     private function createLoopMock()
     {
         return $this->getMock('React\EventLoop\LoopInterface');

--- a/tests/Socket/Stub/ConnectionStub.php
+++ b/tests/Socket/Stub/ConnectionStub.php
@@ -60,4 +60,9 @@ class ConnectionStub extends EventEmitter implements ConnectionInterface
     {
         return '127.0.0.1';
     }
+
+    public function getRemotePort()
+    {
+        return 12345;
+    }
 }


### PR DESCRIPTION
Hi. There is a method Connection::getRemoteAddress allowing to retreive peer's ip. I was surprised why there is no similar method to get remote peer's port (which could be useful for logging or fingerprinting for example). So I've added this functionality as Connection::getRemotePort.