### PR TITLE
Add context and protocol options to SocketClient connector

### DIFF
--- a/src/React/SocketClient/README.md
+++ b/src/React/SocketClient/README.md
@@ -60,3 +60,36 @@ $secureConnector->create('www.google.com', 443)->then(function (React\Stream\Str
     ...
 });
 ```
+
+### UDP connexion
+
+```php
+$connector = new React\SocketClient\Connector($loop, $dns);
+
+$connector->create('nic.com', 715, 'udp')->then(function (React\Stream\Stream $stream) {
+    $stream->write('...');
+    $stream->close();
+});
+```
+
+### Adding context
+If you need to add a certificate or bind to a specific ip address
+
+```php
+$context = stream_context_create(array(
+    'socket'=>array(
+        'bindto'=>"other.local.ip.address"
+    ),
+    'tls'=>array(
+        'local_cert' => 'mycertificate.pem',
+        'passphrase' => 'realpassword'
+    )
+));
+$connector = new React\SocketClient\Connector($loop, $dns);
+
+$connector->create('test.com', 80)->then(function (React\Stream\Stream $stream) {
+    $stream->write('...');
+    $stream->close();
+});
+
+```


### PR DESCRIPTION
Add an optionnal $context option on SocketClient/Connector
It accepts a valid stream_context_create ressource

This way it's easier to add binding or local certificate on tls

Add also optionnal protocol on create, default is still tcp, but you can use others like udp or tls

Doc updated