### PR TITLE
Avoid warning when catching signal with pcntl_signal()

### DIFF
--- a/src/EventLoop/StreamSelectLoop.php
+++ b/src/EventLoop/StreamSelectLoop.php
@@ -252,7 +252,11 @@ class StreamSelectLoop implements LoopInterface
         if ($read || $write) {
             $except = null;
 
-            return stream_select($read, $write, $except, $timeout === null ? null : 0, $timeout);
+            set_error_handler(function () { return true; }, E_WARNING);
+            $result = stream_select($read, $write, $except, $timeout === null ? null : 0, $timeout);
+            restore_error_handler();
+
+            return $result;
         }
 
         usleep($timeout);

--- a/src/Socket/Server.php
+++ b/src/Socket/Server.php
@@ -31,7 +31,10 @@ class Server extends EventEmitter implements ServerInterface
         stream_set_blocking($this->master, 0);
 
         $this->loop->addReadStream($this->master, function ($master) {
+            set_error_handler(function () { return true; }, E_WARNING);
             $newSocket = stream_socket_accept($master);
+            restore_error_handler();
+            
             if (false === $newSocket) {
                 $this->emit('error', array(new \RuntimeException('Error accepting new connection')));
 

--- a/src/Socket/Server.php
+++ b/src/Socket/Server.php
@@ -31,16 +31,12 @@ class Server extends EventEmitter implements ServerInterface
         stream_set_blocking($this->master, 0);
 
         $this->loop->addReadStream($this->master, function ($master) {
-            $newSocket = @stream_socket_accept($master);
+            $newSocket = stream_socket_accept($master);
             if (false === $newSocket) {
-                // if a system call has been interrupted, forget about it, let's try again and avoid warning messages.
-                if (!$this->hasSystemCallBeenInterrupted()) {
-                    $this->emit('error', array(new \RuntimeException('Error accepting new connection')));
-                }
+                $this->emit('error', array(new \RuntimeException('Error accepting new connection')));
 
                 return;
             }
-            
             $this->handleConnection($newSocket);
         });
     }

--- a/src/Socket/Server.php
+++ b/src/Socket/Server.php
@@ -68,15 +68,4 @@ class Server extends EventEmitter implements ServerInterface
     {
         return new Connection($socket, $this->loop);
     }
-    
-    /**
-     * @return bool
-     */
-    private function hasSystemCallBeenInterrupted()
-    {
-        $lastError = error_get_last();
-
-        // stream_select returns false when the `select` system call is interrupted by an incoming signal
-        return isset($lastError['message']) && false !== stripos($lastError['message'], 'interrupted system call');
-    }
 }

--- a/src/Socket/Server.php
+++ b/src/Socket/Server.php
@@ -31,9 +31,7 @@ class Server extends EventEmitter implements ServerInterface
         stream_set_blocking($this->master, 0);
 
         $this->loop->addReadStream($this->master, function ($master) {
-            set_error_handler(function () { return true; }, E_WARNING);
             $newSocket = stream_socket_accept($master);
-            restore_error_handler();
             
             if (false === $newSocket) {
                 $this->emit('error', array(new \RuntimeException('Error accepting new connection')));


### PR DESCRIPTION
Creating a temporary error handler when selecting/accepting a stream to avoid warning messages, caused by catching a signal with function `pcntl_signal()`.

See issue : https://github.com/reactphp/react/issues/296