### PR TITLE
travis-init.sh: drop --dev for composer

### DIFF
--- a/scripts/travis-init.sh
+++ b/scripts/travis-init.sh
@@ -33,4 +33,4 @@ if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then
 fi
 
 composer self-update
-composer install --dev --prefer-source
+composer install --prefer-source


### PR DESCRIPTION
It's default for almost a year