### PR TITLE
Change $loop visibilty to allow inheritance use

### DIFF
--- a/src/Socket/Server.php
+++ b/src/Socket/Server.php
@@ -9,7 +9,7 @@ use React\EventLoop\LoopInterface;
 class Server extends EventEmitter implements ServerInterface
 {
     public $master;
-    private $loop;
+    protected $loop;
 
     public function __construct(LoopInterface $loop)
     {


### PR DESCRIPTION
This should be great to have access to the loop variable in a child class that extends the Server one.