### PR TITLE
Skip integration tests relying on stable internet connection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ install:
   - composer install --no-interaction
 
 script:
-  - php vendor/bin/phpunit --coverage-text
+  - php vendor/bin/phpunit --coverage-text --exclude-group internet

--- a/README.md
+++ b/README.md
@@ -137,6 +137,15 @@ To run the test suite, go to the project root and run:
 $ php vendor/bin/phpunit
 ```
 
+The test suite also contains a number of functional integration tests that rely
+on a stable internet connection. Due to the vast number of integration tests,
+these are skipped by default on Travis CI. If you also do not want to run these,
+they can simply be skipped like this:
+
+```bash
+$ php vendor/bin/phpunit --exclude-group internet
+```
+
 ## License
 
 MIT, see LICENSE.


### PR DESCRIPTION
Tests are currently somewhat flaky on Travis CI because many tests require a stable internet connection. These tests are now skipped by default which significantly reduces the number of false negative test runs.

Builds on top of #396 and #398